### PR TITLE
Make `Weekday.rawValue` correspond to `DateComponents.weekday` value.

### DIFF
--- a/Sources/TimeKit/Calendar.swift
+++ b/Sources/TimeKit/Calendar.swift
@@ -171,7 +171,7 @@ public extension Calendar {
     /// - Parameter date: the date to search.
     /// - Returns: a Weekday for a given Date.
     func weekday(for date: Date) -> Weekday {
-        let weekday = dateComponents([.weekday], from: date).weekday! - 1
+        let weekday = dateComponents([.weekday], from: date).weekday!
         return Weekday(rawValue: weekday)
     }
     

--- a/Sources/TimeKit/Weekday.swift
+++ b/Sources/TimeKit/Weekday.swift
@@ -11,7 +11,7 @@ import Foundation
 /// `rawValue` corresponds to the value returned by `DateComponents.weekday`.
 public enum Weekday: Int, CaseIterable, Hashable, Codable {
     /// sunday
-    case sunday
+    case sunday = 1
     /// monday
     case monday
     /// tuesday
@@ -27,19 +27,19 @@ public enum Weekday: Int, CaseIterable, Hashable, Codable {
     
     public init(rawValue: Int) {
         switch (rawValue % 7) {
-        case 0:
-            self = .sunday
         case 1, -6:
-            self = .monday
+            self = .sunday
         case 2, -5:
-            self = .tuesday
+            self = .monday
         case 3, -4:
-            self = .wednesday
+            self = .tuesday
         case 4, -3:
-            self = .thursday
+            self = .wednesday
         case 5, -2:
-            self = .friday
+            self = .thursday
         case 6, -1:
+            self = .friday
+        case 0:
             self = .saturday
         default:
             fatalError()

--- a/Tests/TimeKitTests/WeekdayTests.swift
+++ b/Tests/TimeKitTests/WeekdayTests.swift
@@ -11,13 +11,13 @@ import XCTest
 final class WeekdayTests: XCTestCase {
     
     func testNegativeRawValue() {
-        XCTAssertEqual(Weekday(rawValue: -7), .sunday)
-        XCTAssertEqual(Weekday(rawValue: -6), .monday)
-        XCTAssertEqual(Weekday(rawValue: -5), .tuesday)
-        XCTAssertEqual(Weekday(rawValue: -4), .wednesday)
-        XCTAssertEqual(Weekday(rawValue: -3), .thursday)
-        XCTAssertEqual(Weekday(rawValue: -2), .friday)
-        XCTAssertEqual(Weekday(rawValue: -1), .saturday)
+        XCTAssertEqual(Weekday(rawValue: -6), .sunday)
+        XCTAssertEqual(Weekday(rawValue: -5), .monday)
+        XCTAssertEqual(Weekday(rawValue: -4), .tuesday)
+        XCTAssertEqual(Weekday(rawValue: -3), .wednesday)
+        XCTAssertEqual(Weekday(rawValue: -2), .thursday)
+        XCTAssertEqual(Weekday(rawValue: -1), .friday)
+        XCTAssertEqual(Weekday(rawValue: -7), .saturday)
     }
     
     func testAdding() {


### PR DESCRIPTION
`Weekday.rawValue` don't correspond to `DateComponents.weekday` value.
I feel like this may cause some bugs.

## Before

|Weekday|Weekday.rawValue|DateComponents.weekday|
|:-:|:-:|:-:|
|Sunday|0|1|
|Monday|1|2|
|Tuesday|2|3|
|Wednesday|3|4|
|Thursday|4|5|
|Friday|5|6|
|Saturday|6|7|

## After

|Weekday|Weekday.rawValue|DateComponents.weekday|
|:-:|:-:|:-:|
|Sunday|**1**|1|
|Monday|**2**|2|
|Tuesday|**3**|3|
|Wednesday|**4**|4|
|Thursday|**5**|5|
|Friday|**6**|6|
|Saturday|**7**|7|